### PR TITLE
Potential fix for code scanning alert no. 1: Bad HTML filtering regexp

### DIFF
--- a/scratch-svg-renderer/src/fixup-svg-string.js
+++ b/scratch-svg-renderer/src/fixup-svg-string.js
@@ -55,7 +55,7 @@ module.exports = function (svgString) {
     svgString = svgString.replace(/<metadata>[\s\S]*<\/metadata>/, '<metadata></metadata>');
 
     // Empty script tags and javascript executing
-    svgString = svgString.replace(/<script[\s\S]*>[\s\S]*<\/script>/, '<script></script>');
+    svgString = svgString.replace(/<script[\s\S]*>[\s\S]*<\/script>/gi, '<script></script>');
 
     return svgString;
 };

--- a/scratch-svg-renderer/src/fixup-svg-string.js
+++ b/scratch-svg-renderer/src/fixup-svg-string.js
@@ -55,7 +55,7 @@ module.exports = function (svgString) {
     svgString = svgString.replace(/<metadata>[\s\S]*<\/metadata>/, '<metadata></metadata>');
 
     // Empty script tags and javascript executing
-    svgString = svgString.replace(/<script[\s\S]*>[\s\S]*<\/script>/gi, '<script></script>');
+    svgString = svgString.replace(/<script\b[^>]*>[\s\S]*?<\/script\b[^>]*>/gi, '<script></script>');
 
     return svgString;
 };


### PR DESCRIPTION
Potential fix for [https://github.com/OmniBlocks/monorepo/security/code-scanning/1](https://github.com/OmniBlocks/monorepo/security/code-scanning/1)

Use a case-insensitive regex for the script-tag neutralization, so `<script>`, `<SCRIPT>`, and mixed-case variants are all matched. Keep behavior otherwise unchanged (still replacing matched content with `<script></script>`).

Best minimal fix in `scratch-svg-renderer/src/fixup-svg-string.js`:
- Update line 58 regex from:
  - `/<script[\s\S]*>[\s\S]*<\/script>/`
- To:
  - `/<script[\s\S]*>[\s\S]*<\/script>/gi`

This preserves existing logic and only broadens matching to case variants (and consistently handles multiple matches).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
